### PR TITLE
Fix LocateFile_ag error while Bundling with Vundle

### DIFF
--- a/plugin/ag.vim
+++ b/plugin/ag.vim
@@ -280,7 +280,7 @@ else
   call add(g:EclimLocateUserScopes, 'ag')
 endif
 
-function LocateFile_ag(pattern) " {{{
+function! LocateFile_ag(pattern) " {{{
   if len(a:pattern) >= 5
     let command = '`ag --search-files -g "' . a:pattern . '"`'
     let results = split(eclim#util#Glob(command, 1), "\n")


### PR DESCRIPTION
When running `:BundleInstall` from Vundle to install ag.vim, this error
is thrown:

```
Error detected while processing
/Users/david/Documents/Code/dotfiles/vim/bundle/ag/plugin/ag.vim:
line  299:
E122: Function LocateFile_ag already exists, add ! to replace it
```

So, defined LocateFile_ag using `function!` instead.

Signed-off-by: David Celis me@davidcel.is
