### PR TITLE
Use word-under-cursor for call without argument

### DIFF
--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -73,7 +73,11 @@ function! ag#Ag(args, relative, bang) " {{{
     exec 'cd ' . expand('%:p:h')
   endif
 
-  let args = s:ParseArgs(a:args)
+  if empty(a:args)
+    let args = s:ParseArgs(expand("<cword>"))
+  else
+    let args = s:ParseArgs(a:args)
+  end
   " if pattern and dir supplied, see if dir is a glob pattern
   let [options, non_option_args] = s:SplitOptionsFromArgs(args)
   if len(non_option_args) == 2

--- a/autoload/ag.vim
+++ b/autoload/ag.vim
@@ -74,7 +74,7 @@ function! ag#Ag(args, relative, bang) " {{{
   endif
 
   if empty(a:args)
-    let args = s:ParseArgs(expand("<cword>"))
+    let args = s:ParseArgs("\\<" . expand("<cword>") . "\\>")
   else
     let args = s:ParseArgs(a:args)
   end

--- a/plugin/ag.vim
+++ b/plugin/ag.vim
@@ -54,11 +54,11 @@ let g:AgSmartCase = 0
 
 " Command Declarations {{{
 if exists(":Ag") != 2
-  command -bang -nargs=+ -complete=customlist,ag#Complete
+  command -bang -nargs=* -complete=customlist,ag#Complete
     \ Ag :call ag#Ag(<q-args>, 0, '<bang>')
 endif
 if exists(":AgRelative") != 2
-  command -bang -nargs=+ -complete=customlist,ag#CompleteRelative
+  command -bang -nargs=* -complete=customlist,ag#CompleteRelative
     \ AgRelative :call ag#Ag(<q-args>, 1, '<bang>')
 endif
 " }}}


### PR DESCRIPTION
This seems to work for me. Can probably be improved upon.